### PR TITLE
PT-4279: fix - settings is empty after saving changes

### DIFF
--- a/src/VirtoCommerce.TaxModule.Data/Services/TaxProviderService.cs
+++ b/src/VirtoCommerce.TaxModule.Data/Services/TaxProviderService.cs
@@ -44,7 +44,7 @@ namespace VirtoCommerce.TaxModule.Data.Services
             {
                 entity.ToModel(taxProvider);
 
-                _settingManager.DeepLoadSettingsAsync(taxProvider);
+                _settingManager.DeepLoadSettingsAsync(taxProvider).GetAwaiter().GetResult();
                 return taxProvider;
             }
             return null;


### PR DESCRIPTION
## Description
Store > Tax providers > Settings is empty after saving changes
## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-4279
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Tax_3.9.0-pr-27.zip
