### PR TITLE
fix: tax providers list UI fix

### DIFF
--- a/src/VirtoCommerce.TaxModule.Web/Scripts/blades/taxProvider-list.js
+++ b/src/VirtoCommerce.TaxModule.Web/Scripts/blades/taxProvider-list.js
@@ -3,7 +3,7 @@ angular.module('virtoCommerce.taxModule').controller('virtoCommerce.taxModule.ta
 
     blade.refresh = function() {
         blade.isLoading = true;
-        taxProviders.search({ storeId: blade.storeId },
+        taxProviders.search({ storeIds: [blade.storeId] },
             function(data) {
                 blade.isLoading = false;
                 blade.currentEntities = data.results;


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Tax_3.1003.0-pr-55-abc1.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-parameter fix in admin UI list refresh; no auth, data model, or backend changes.
> 
> **Overview**
> Fixes the store tax providers list blade so refresh loads providers for the current store again.
> 
> `taxProvider-list.js` now calls `taxProviders.search` with **`storeIds: [blade.storeId]`** instead of **`storeId`**, matching **`TaxProviderSearchCriteria.StoreIds`** used by the tax provider search API (same shape as elsewhere, e.g. evaluate taxes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc18f5a09a6e1f7f465c0257e5ea0c03be9f4d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->