### PR TITLE
VCST-5163: Stable 15 — Tax (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.TaxModule.Core/VirtoCommerce.TaxModule.Core.csproj
+++ b/src/VirtoCommerce.TaxModule.Core/VirtoCommerce.TaxModule.Core.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.TaxModule.Data.MySql/VirtoCommerce.TaxModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.TaxModule.Data.MySql/VirtoCommerce.TaxModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.TaxModule.Data\VirtoCommerce.TaxModule.Data.csproj" />

--- a/src/VirtoCommerce.TaxModule.Data.PostgreSql/VirtoCommerce.TaxModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.TaxModule.Data.PostgreSql/VirtoCommerce.TaxModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.TaxModule.Data\VirtoCommerce.TaxModule.Data.csproj" />

--- a/src/VirtoCommerce.TaxModule.Data.SqlServer/VirtoCommerce.TaxModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.TaxModule.Data.SqlServer/VirtoCommerce.TaxModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.TaxModule.Data\VirtoCommerce.TaxModule.Data.csproj" />

--- a/src/VirtoCommerce.TaxModule.Data/ExportImport/TaxExportImport.cs
+++ b/src/VirtoCommerce.TaxModule.Data/ExportImport/TaxExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -24,7 +25,7 @@ namespace VirtoCommerce.TaxModule.Data.ExportImport
             _taxProviderSearchService = taxProviderSearchService;
         }
 
-        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -60,7 +61,7 @@ namespace VirtoCommerce.TaxModule.Data.ExportImport
             }
         }
 
-        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/VirtoCommerce.TaxModule.Data/ExportImport/TaxExportImport.cs
+++ b/src/VirtoCommerce.TaxModule.Data/ExportImport/TaxExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+
 using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
@@ -35,12 +36,12 @@ namespace VirtoCommerce.TaxModule.Data.ExportImport
             using (var sw = new StreamWriter(outStream))
             using (var writer = new JsonTextWriter(sw))
             {
-                await writer.WriteStartObjectAsync();
+                await writer.WriteStartObjectAsync(cancellationToken);
 
                 progressInfo.Description = "Tax providers are started to export";
                 progressCallback(progressInfo);
 
-                await writer.WritePropertyNameAsync("TaxProviders");
+                await writer.WritePropertyNameAsync("TaxProviders", cancellationToken);
                 await writer.SerializeArrayWithPagingAsync(_jsonSerializer, _batchSize, async (skip, take) =>
                 {
                     var searchCriteria = AbstractTypeFactory<TaxProviderSearchCriteria>.TryCreateInstance();
@@ -56,8 +57,8 @@ namespace VirtoCommerce.TaxModule.Data.ExportImport
                     progressCallback(progressInfo);
                 }, cancellationToken);
 
-                await writer.WriteEndObjectAsync();
-                await writer.FlushAsync();
+                await writer.WriteEndObjectAsync(cancellationToken);
+                await writer.FlushAsync(cancellationToken);
             }
         }
 
@@ -70,7 +71,7 @@ namespace VirtoCommerce.TaxModule.Data.ExportImport
             using (var streamReader = new StreamReader(inputStream))
             using (var reader = new JsonTextReader(streamReader))
             {
-                while (await reader.ReadAsync())
+                while (await reader.ReadAsync(cancellationToken))
                 {
                     if (reader.TokenType == JsonToken.PropertyName)
                     {

--- a/src/VirtoCommerce.TaxModule.Data/VirtoCommerce.TaxModule.Data.csproj
+++ b/src/VirtoCommerce.TaxModule.Data/VirtoCommerce.TaxModule.Data.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.TaxModule.Core\VirtoCommerce.TaxModule.Core.csproj" />

--- a/src/VirtoCommerce.TaxModule.Web/Module.cs
+++ b/src/VirtoCommerce.TaxModule.Web/Module.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -96,13 +97,13 @@ namespace VirtoCommerce.TaxModule.Web
         }
 
         public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<TaxExportImport>().DoExportAsync(outStream, progressCallback, cancellationToken);
         }
 
         public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<TaxExportImport>().DoImportAsync(inputStream, progressCallback, cancellationToken);
         }

--- a/src/VirtoCommerce.TaxModule.Web/module.manifest
+++ b/src/VirtoCommerce.TaxModule.Web/module.manifest
@@ -3,10 +3,10 @@
   <id>VirtoCommerce.Tax</id>
   <version>3.1003.0</version>
   <version-tag />
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
   </dependencies>
   <title>Tax Core</title>
   <description>Defines Core Abstractions for taxes evaluation by using different tax providers and FixedRateTaxProvider.</description>


### PR DESCRIPTION
Part of **Stable 15** (Wave 4). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–3 packages on nuget.org. Version handled by CI.

- ICancellationToken→CancellationToken migration.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches platform-wide export/import cancellation contracts and dependency versions; behavior should be equivalent but misalignment with host platform would break builds or import/export at runtime.
> 
> **Overview**
> Updates the Tax module for **Stable 15** by targeting VirtoCommerce platform **3.1039.0** and bumping related NuGet references (`VirtoCommerce.Platform.*`, `VirtoCommerce.CoreModule.Core`) plus `module.manifest` platform and Core/Store dependency versions.
> 
> Export/import is migrated from **`ICancellationToken` to `System.Threading.CancellationToken`** on `Module` and `TaxExportImport`, with cancellation tokens passed through Newtonsoft JSON async writes/reads so long-running tax provider export/import can honor cancellation under the new platform contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c1a4e2ea3069c6e415a579538015863f1d29b3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Tax_3.1003.0-pr-56-0c1a.zip