### PR TITLE
VCST-5303 perf: decide the sort fast path from BuildSortExpression, not from the criteria

### DIFF
--- a/src/VirtoCommerce.TaxModule.Data/Services/TaxProviderSearchService.cs
+++ b/src/VirtoCommerce.TaxModule.Data/Services/TaxProviderSearchService.cs
@@ -18,6 +18,8 @@ namespace VirtoCommerce.TaxModule.Data.Services
 {
     public class TaxProviderSearchService : SearchService<TaxProviderSearchCriteria, TaxProviderSearchResult, TaxProvider, StoreTaxProviderEntity>, ITaxProviderSearchService
     {
+        protected const string DefaultSortColumn = nameof(StoreTaxProviderEntity.Code);
+
         private readonly ISettingsManager _settingManager;
 
         public TaxProviderSearchService(
@@ -65,8 +67,10 @@ namespace VirtoCommerce.TaxModule.Data.Services
 
                 var allProviders = result.Results.Concat(pagedTransientProviders);
 
-                // Hot default Code sort avoids OrderBySortInfos' per-call expression compile; admin sorts (cold) keep the generic path.
-                result.Results = criteria.SortInfos.IsNullOrEmpty()
+                // Arbitrary sort columns (admin, cold) are worth OrderBySortInfos' compile; the default
+                // order is not. Decided from what BuildSortExpression returned, so overriding that seam
+                // still changes the sort.
+                result.Results = IsSingleAscendingDefaultSort(sortInfos)
                     ? allProviders.OrderBy(x => x.Code).ThenBy(x => x.Id).ToList()
                     : allProviders.AsQueryable().OrderBySortInfos(sortInfos).ThenBy(x => x.Id).ToList();
             }
@@ -101,12 +105,19 @@ namespace VirtoCommerce.TaxModule.Data.Services
                 {
                     new SortInfo
                     {
-                        SortColumn = nameof(StoreTaxProviderEntity.Code)
+                        SortColumn = DefaultSortColumn
                     }
                 };
             }
 
             return sortInfos;
+        }
+
+        protected static bool IsSingleAscendingDefaultSort(IList<SortInfo> sortInfos)
+        {
+            return sortInfos?.Count == 1
+                && sortInfos[0].SortDirection == SortDirection.Ascending
+                && DefaultSortColumn.EqualsIgnoreCase(sortInfos[0].SortColumn);
         }
     }
 }

--- a/tests/VirtoCommerce.TaxModule.Data.Tests/Services/TaxProviderSearchServiceTests.cs
+++ b/tests/VirtoCommerce.TaxModule.Data.Tests/Services/TaxProviderSearchServiceTests.cs
@@ -140,6 +140,22 @@ namespace VirtoCommerce.TaxModule.Data.Tests.Services
         }
 
         [Fact]
+        public async Task ProcessSearchResult_ExplicitAscendingCodeSort_MatchesDefaultSort()
+        {
+            // The one case the sort fast path took over from the generic OrderBySortInfos path: an
+            // explicitly requested ascending Code sort. Asserted on the resulting order rather than on
+            // which branch ran, so the guard survives a future change of that boundary.
+            var service = CreateService();
+            var result = new TaxProviderSearchResult();
+            var criteria = new TaxProviderSearchCriteria { Take = 20, Sort = "Code" };
+
+            await service.RunProcessSearchResultAsync(result, criteria);
+
+            var codes = result.Results.Select(x => x.Code).ToList();
+            Assert.Equal(new[] { "aaa", "bbb", "ccc" }, codes);
+        }
+
+        [Fact]
         public async Task ProcessSearchResult_WithoutTransient_LeavesResultUntouched()
         {
             var service = CreateService();


### PR DESCRIPTION
Follow-up to #57, which added the sort fast path in `TaxProviderSearchService.ProcessSearchResultAsync`.

## The problem

The fast path selected itself by reading `criteria.SortInfos.IsNullOrEmpty()`:

```csharp
result.Results = criteria.SortInfos.IsNullOrEmpty()
    ? allProviders.OrderBy(x => x.Code).ThenBy(x => x.Id).ToList()
    : allProviders.AsQueryable().OrderBySortInfos(sortInfos).ThenBy(x => x.Id).ToList();
```

That duplicates the default-sort knowledge which already lives in `BuildSortExpression`, and the
duplication is only the visible half. The consequence is that **the fast path decides the default sort
itself**, so a subclass overriding that `protected virtual` seam to default to another column has its
override silently ignored and still gets Code order — an optimization bypassing an extension seam, with
no compile error and no test failure to signal it. The branch also discarded the `sortInfos` the method
had already built.

## The fix

Decide from the seam's **output** instead of from the criteria:

```csharp
result.Results = IsSingleAscendingDefaultSort(sortInfos)
    ? allProviders.OrderBy(x => x.Code).ThenBy(x => x.Id).ToList()
    : allProviders.AsQueryable().OrderBySortInfos(sortInfos).ThenBy(x => x.Id).ToList();
```

The predicate is tested against the sort the fast lambda actually performs — one ascending sort on the
column it orders by — not against "the default" as a concept. An override returning anything else routes
through the generic path and works again. `DefaultSortColumn` holds the column name once, so
`BuildSortExpression` and the predicate cannot drift apart. Nothing is computed and thrown away.

## Equivalence

One behaviour class moves: an explicitly requested ascending `Code` sort now takes the fast path
(previously only an absent sort did). It is equivalent — both paths end in `Enumerable.OrderBy` with
`Comparer<string>.Default` and keep the `ThenBy(x => x.Id)` tie-breaker, so collation and stable tie
order are identical; and the predicate's case-insensitive column match mirrors `ApplyOrder`'s own
`BindingFlags.IgnoreCase` property lookup, so `Sort=code` behaves as `Sort=Code` did.

Pinned by a new test: the two existing sort tests cover the default order and `Code:desc`, i.e. exactly
the two cases that did **not** move.

`Code:desc`, multi-column sorts and non-`Code` columns are untouched and keep the generic path.

## Scope

The same shape was mirrored into `vc-module-payment` (VirtoCommerce/vc-module-payment#74) and
`vc-module-shipping` (VirtoCommerce/vc-module-shipping#70) from this implementation; all three now match,
as review asked. `vc-module-pricing` was checked and is unaffected — it has no `ProcessSearchResultAsync`
override, so it has no in-memory sort fast path at all.

## Verification

`dotnet build` clean (0 warnings) and 10/10 tests green.

The perf value of the fast path this preserves, measured on a 1-vCPU-capped stand under a steady 5-VU
cart/checkout load, A/B on one stand in one session: the two `EnumerableQuery` frames held **70.7% of all
non-idle CPU** before the original fix and ~0.5% after, all non-idle work fell **-72.9%**, and
`IQueryProvider.Execute` / `LambdaCompiler` / `DynamicResolver+DestroyScout.Finalize` disappeared entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral tweak to in-memory sorting only; default and explicit ascending Code order stay equivalent, with a new test pinning that case.
> 
> **Overview**
> **Tax provider search** no longer picks the in-memory sort fast path from empty `criteria.SortInfos`. It uses **`IsSingleAscendingDefaultSort`** on the list returned by **`BuildSortExpression`**, with **`DefaultSortColumn`** shared so default sort and the fast-path guard stay aligned.
> 
> Subclasses that override **`BuildSortExpression`** to change the default column are respected again instead of always getting hard-coded **`Code`** order. Explicit **`Sort=Code`** (ascending) now uses the same fast path as an omitted sort; **`Code:desc`**, multi-column, and non-Code sorts still go through **`OrderBySortInfos`**.
> 
> A test asserts ascending **`Code`** ordering matches the default-sort behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36eaf56f711bda505603203ee362768b7333af1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5303
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Tax_3.1005.0-pr-58-36ea.zip